### PR TITLE
#40 Harmonize Bot and BotBuilder arguments and method names

### DIFF
--- a/src/Bot.php
+++ b/src/Bot.php
@@ -38,18 +38,18 @@ class Bot extends Generated
     public function __construct(
         string $token,
         string $handlerPath = null,
-        string $customServer = null,
+        string $baseUri = null,
         string $httpProxy = null,
         ContainerInterface $container = null,
         CacheInterface|CacheItemPoolInterface $cache = null,
         LoggerInterface $logger = null,
         EventDispatcherInterface $eventDispatcher = null,
     ) {
-        if ($customServer === null) {
-            $customServer = self::DEFAULT_API_SERVER_URL;
+        if ($baseUri === null) {
+            $baseUri = self::DEFAULT_API_SERVER_URL;
         }
 
-        parent::__construct($token, $customServer);
+        parent::__construct($token, $baseUri);
 
         $this->makeServiceContainer($container, $cache, $logger, $eventDispatcher);
 

--- a/src/BotBuilder.php
+++ b/src/BotBuilder.php
@@ -14,7 +14,7 @@ class BotBuilder
 
     protected ?string $token = null;
 
-    protected ?string $customServer = null;
+    protected ?string $baseUri = null;
 
     protected ?string $httpProxy = null;
 
@@ -35,9 +35,9 @@ class BotBuilder
         return $this;
     }
 
-    final public function customServer(?string $customServer): static
+    final public function baseUri(?string $baseUri): static
     {
-        $this->customServer = $customServer;
+        $this->baseUri = $baseUri;
 
         return $this;
     }
@@ -93,7 +93,7 @@ class BotBuilder
         return new Bot(
             token: $this->token,
             handlerPath: $this->handlerPath,
-            customServer: $this->customServer,
+            baseUri: $this->baseUri,
             httpProxy: $this->httpProxy,
             container: $this->container,
             cache: $this->cache,

--- a/src/Commands/BotCommand.php
+++ b/src/Commands/BotCommand.php
@@ -74,7 +74,7 @@ abstract class BotCommand extends Command
         $proxy = $input->getOption('proxy') ?? $_ENV['TELEPATH_PROXY'] ?? null;
 
         return BotBuilder::token($token)
-            ->customServer($apiUrl)
+            ->baseUri($apiUrl)
             ->httpProxy($proxy)
             ->build();
     }


### PR DESCRIPTION
Fixes #40 and harmonize Bot and BotBuilder arguments and method names by switching from "customServer" to "baseUri".