### PR TITLE
Added caching to username() method

### DIFF
--- a/src/Bot.php
+++ b/src/Bot.php
@@ -223,7 +223,7 @@ class Bot extends Generated
         return $this->middleware;
     }
 
-    protected function username(): string
+    public function username(): string
     {
         // Check memory
         if ($this->username !== null) {

--- a/src/Handlers/Message/Command.php
+++ b/src/Handlers/Message/Command.php
@@ -28,7 +28,7 @@ class Command extends Message
         if (str_contains($command, '@')) {
             [$command, $username] = explode('@', $command, 2);
 
-            if ($username !== $bot->username) {
+            if ($username !== $bot->username()) {
                 return false;
             }
         }


### PR DESCRIPTION
This deprecates the use of the public $bot->username property and moves to a $bot->username() method.

This PR solves #23 as good as it can be, I guess.